### PR TITLE
Remove debug from production settings

### DIFF
--- a/app/settings/production.py
+++ b/app/settings/production.py
@@ -1,7 +1,7 @@
 # ruff: noqa
 from app.settings.base import *
 
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = [
     "*",  # FIXME: replace with production IPs


### PR DESCRIPTION
Removes the `DEBUG = True` flag from the production settings